### PR TITLE
Stop using a dot import in the controller implementation

### DIFF
--- a/codegen/render/funcs.go
+++ b/codegen/render/funcs.go
@@ -86,8 +86,6 @@ func makeTemplateFuncs() template.FuncMap {
 	return f
 }
 
-
-
 /*
 	Find the proto messages for a given set of descriptors which need proto_deepcopoy funcs and whose types are not in
 	the API root package

--- a/codegen/render/funcs.go
+++ b/codegen/render/funcs.go
@@ -41,6 +41,12 @@ func makeTemplateFuncs() template.FuncMap {
 		"group_import_path": func(grp Group) string {
 			return util.GoPackage(grp)
 		},
+		"group_import_name": func(grp Group) string {
+			name := strings.ReplaceAll(grp.GroupVersion.String(), "/", "_")
+			name = strings.ReplaceAll(name, ".", "_")
+
+			return name
+		},
 		// Used by types.go to get all unique external imports for a groups resources
 		"imports_for_group": func(grp Group) []string {
 			return uniqueGoPackagesForGroup(grp)

--- a/codegen/templates/code/controller/controller.gotmpl
+++ b/codegen/templates/code/controller/controller.gotmpl
@@ -4,7 +4,7 @@ package controller
 import (
 	"context"
 
-    . "{{ group_import_path $ }}"
+    autopilot_kind_import "{{ group_import_path $ }}"
 
     "github.com/pkg/errors"
     "github.com/solo-io/autopilot/pkg/events"
@@ -16,41 +16,41 @@ import (
 {{- range $resource := $.Resources }}
 
 type {{ $resource.Kind }}EventHandler interface {
-    Create(obj *{{ $resource.Kind }}) error
-    Update(old, new *{{ $resource.Kind }}) error
-    Delete(obj *{{ $resource.Kind }}) error
-    Generic(obj *{{ $resource.Kind }}) error
+    Create(obj *autopilot_kind_import.{{ $resource.Kind }}) error
+    Update(old, new *autopilot_kind_import.{{ $resource.Kind }}) error
+    Delete(obj *autopilot_kind_import.{{ $resource.Kind }}) error
+    Generic(obj *autopilot_kind_import.{{ $resource.Kind }}) error
 }
 
 type {{ $resource.Kind }}EventHandlerFuncs struct {
-    OnCreate  func(obj *{{ $resource.Kind }}) error
-    OnUpdate  func(old, new *{{ $resource.Kind }}) error
-    OnDelete  func(obj *{{ $resource.Kind }}) error
-    OnGeneric func(obj *{{ $resource.Kind }}) error
+    OnCreate  func(obj *autopilot_kind_import.{{ $resource.Kind }}) error
+    OnUpdate  func(old, new *autopilot_kind_import.{{ $resource.Kind }}) error
+    OnDelete  func(obj *autopilot_kind_import.{{ $resource.Kind }}) error
+    OnGeneric func(obj *autopilot_kind_import.{{ $resource.Kind }}) error
 }
 
-func (f *{{ $resource.Kind }}EventHandlerFuncs) Create(obj *{{ $resource.Kind }}) error {
+func (f *{{ $resource.Kind }}EventHandlerFuncs) Create(obj *autopilot_kind_import.{{ $resource.Kind }}) error {
     if f.OnCreate == nil {
         return nil
     }
     return f.OnCreate(obj)
 }
 
-func (f *{{ $resource.Kind }}EventHandlerFuncs) Delete(obj *{{ $resource.Kind }}) error {
+func (f *{{ $resource.Kind }}EventHandlerFuncs) Delete(obj *autopilot_kind_import.{{ $resource.Kind }}) error {
     if f.OnDelete == nil {
         return nil
     }
     return f.OnDelete(obj)
 }
 
-func (f *{{ $resource.Kind }}EventHandlerFuncs) Update(objOld, objNew *{{ $resource.Kind }}) error {
+func (f *{{ $resource.Kind }}EventHandlerFuncs) Update(objOld, objNew *autopilot_kind_import.{{ $resource.Kind }}) error {
     if f.OnUpdate == nil {
         return nil
     }
     return f.OnUpdate(objOld, objNew)
 }
 
-func (f *{{ $resource.Kind }}EventHandlerFuncs) Generic(obj *{{ $resource.Kind }}) error {
+func (f *{{ $resource.Kind }}EventHandlerFuncs) Generic(obj *autopilot_kind_import.{{ $resource.Kind }}) error {
     if f.OnGeneric == nil {
         return nil
     }
@@ -66,7 +66,7 @@ type {{ $resource.Kind }}ControllerImpl struct {
 }
 
 func New{{ $resource.Kind }}Controller(name string, mgr manager.Manager) ({{ $resource.Kind }}Controller, error) {
-    if err := AddToScheme(mgr.GetScheme()); err != nil {
+    if err := autopilot_kind_import.AddToScheme(mgr.GetScheme()); err != nil {
         return nil, err
     }
 
@@ -81,7 +81,7 @@ func New{{ $resource.Kind }}Controller(name string, mgr manager.Manager) ({{ $re
 
 func (c *{{ $resource.Kind }}ControllerImpl) AddEventHandler(ctx context.Context, h {{ $resource.Kind }}EventHandler, predicates ...predicate.Predicate) error {
 	handler := generic{{ $resource.Kind }}Handler{handler: h}
-    if err := c.watcher.Watch(ctx, &{{ $resource.Kind }}{}, handler, predicates...); err != nil{
+    if err := c.watcher.Watch(ctx, &autopilot_kind_import.{{ $resource.Kind }}{}, handler, predicates...); err != nil{
         return err
     }
     return nil
@@ -93,7 +93,7 @@ type generic{{ $resource.Kind }}Handler struct {
 }
 
 func (h generic{{ $resource.Kind }}Handler) Create(object runtime.Object) error {
-    obj, ok := object.(*{{ $resource.Kind }})
+    obj, ok := object.(*autopilot_kind_import.{{ $resource.Kind }})
     if !ok {
         return errors.Errorf("internal error: {{ $resource.Kind }} handler received event for %T", object)
     }
@@ -101,7 +101,7 @@ func (h generic{{ $resource.Kind }}Handler) Create(object runtime.Object) error 
 }
 
 func (h generic{{ $resource.Kind }}Handler) Delete(object runtime.Object) error {
-    obj, ok := object.(*{{ $resource.Kind }})
+    obj, ok := object.(*autopilot_kind_import.{{ $resource.Kind }})
     if !ok {
         return errors.Errorf("internal error: {{ $resource.Kind }} handler received event for %T", object)
     }
@@ -109,11 +109,11 @@ func (h generic{{ $resource.Kind }}Handler) Delete(object runtime.Object) error 
 }
 
 func (h generic{{ $resource.Kind }}Handler) Update(old, new runtime.Object) error {
-    objOld, ok := old.(*{{ $resource.Kind }})
+    objOld, ok := old.(*autopilot_kind_import.{{ $resource.Kind }})
     if !ok {
         return errors.Errorf("internal error: {{ $resource.Kind }} handler received event for %T", old)
     }
-    objNew, ok := new.(*{{ $resource.Kind }})
+    objNew, ok := new.(*autopilot_kind_import.{{ $resource.Kind }})
     if !ok {
         return errors.Errorf("internal error: {{ $resource.Kind }} handler received event for %T", new)
     }
@@ -121,7 +121,7 @@ func (h generic{{ $resource.Kind }}Handler) Update(old, new runtime.Object) erro
 }
 
 func (h generic{{ $resource.Kind }}Handler) Generic(object runtime.Object) error {
-    obj, ok := object.(*{{ $resource.Kind }})
+    obj, ok := object.(*autopilot_kind_import.{{ $resource.Kind }})
     if !ok {
         return errors.Errorf("internal error: {{ $resource.Kind }} handler received event for %T", object)
     }

--- a/codegen/templates/code/controller/controller.gotmpl
+++ b/codegen/templates/code/controller/controller.gotmpl
@@ -4,7 +4,7 @@ package controller
 import (
 	"context"
 
-    autopilot_kind_import "{{ group_import_path $ }}"
+    {{ group_import_name $ }} "{{ group_import_path $ }}"
 
     "github.com/pkg/errors"
     "github.com/solo-io/autopilot/pkg/events"
@@ -16,41 +16,41 @@ import (
 {{- range $resource := $.Resources }}
 
 type {{ $resource.Kind }}EventHandler interface {
-    Create(obj *autopilot_kind_import.{{ $resource.Kind }}) error
-    Update(old, new *autopilot_kind_import.{{ $resource.Kind }}) error
-    Delete(obj *autopilot_kind_import.{{ $resource.Kind }}) error
-    Generic(obj *autopilot_kind_import.{{ $resource.Kind }}) error
+    Create(obj *{{ group_import_name $ }}.{{ $resource.Kind }}) error
+    Update(old, new *{{ group_import_name $ }}.{{ $resource.Kind }}) error
+    Delete(obj *{{ group_import_name $ }}.{{ $resource.Kind }}) error
+    Generic(obj *{{ group_import_name $ }}.{{ $resource.Kind }}) error
 }
 
 type {{ $resource.Kind }}EventHandlerFuncs struct {
-    OnCreate  func(obj *autopilot_kind_import.{{ $resource.Kind }}) error
-    OnUpdate  func(old, new *autopilot_kind_import.{{ $resource.Kind }}) error
-    OnDelete  func(obj *autopilot_kind_import.{{ $resource.Kind }}) error
-    OnGeneric func(obj *autopilot_kind_import.{{ $resource.Kind }}) error
+    OnCreate  func(obj *{{ group_import_name $ }}.{{ $resource.Kind }}) error
+    OnUpdate  func(old, new *{{ group_import_name $ }}.{{ $resource.Kind }}) error
+    OnDelete  func(obj *{{ group_import_name $ }}.{{ $resource.Kind }}) error
+    OnGeneric func(obj *{{ group_import_name $ }}.{{ $resource.Kind }}) error
 }
 
-func (f *{{ $resource.Kind }}EventHandlerFuncs) Create(obj *autopilot_kind_import.{{ $resource.Kind }}) error {
+func (f *{{ $resource.Kind }}EventHandlerFuncs) Create(obj *{{ group_import_name $ }}.{{ $resource.Kind }}) error {
     if f.OnCreate == nil {
         return nil
     }
     return f.OnCreate(obj)
 }
 
-func (f *{{ $resource.Kind }}EventHandlerFuncs) Delete(obj *autopilot_kind_import.{{ $resource.Kind }}) error {
+func (f *{{ $resource.Kind }}EventHandlerFuncs) Delete(obj *{{ group_import_name $ }}.{{ $resource.Kind }}) error {
     if f.OnDelete == nil {
         return nil
     }
     return f.OnDelete(obj)
 }
 
-func (f *{{ $resource.Kind }}EventHandlerFuncs) Update(objOld, objNew *autopilot_kind_import.{{ $resource.Kind }}) error {
+func (f *{{ $resource.Kind }}EventHandlerFuncs) Update(objOld, objNew *{{ group_import_name $ }}.{{ $resource.Kind }}) error {
     if f.OnUpdate == nil {
         return nil
     }
     return f.OnUpdate(objOld, objNew)
 }
 
-func (f *{{ $resource.Kind }}EventHandlerFuncs) Generic(obj *autopilot_kind_import.{{ $resource.Kind }}) error {
+func (f *{{ $resource.Kind }}EventHandlerFuncs) Generic(obj *{{ group_import_name $ }}.{{ $resource.Kind }}) error {
     if f.OnGeneric == nil {
         return nil
     }
@@ -66,7 +66,7 @@ type {{ $resource.Kind }}ControllerImpl struct {
 }
 
 func New{{ $resource.Kind }}Controller(name string, mgr manager.Manager) ({{ $resource.Kind }}Controller, error) {
-    if err := autopilot_kind_import.AddToScheme(mgr.GetScheme()); err != nil {
+    if err := {{ group_import_name $ }}.AddToScheme(mgr.GetScheme()); err != nil {
         return nil, err
     }
 
@@ -81,7 +81,7 @@ func New{{ $resource.Kind }}Controller(name string, mgr manager.Manager) ({{ $re
 
 func (c *{{ $resource.Kind }}ControllerImpl) AddEventHandler(ctx context.Context, h {{ $resource.Kind }}EventHandler, predicates ...predicate.Predicate) error {
 	handler := generic{{ $resource.Kind }}Handler{handler: h}
-    if err := c.watcher.Watch(ctx, &autopilot_kind_import.{{ $resource.Kind }}{}, handler, predicates...); err != nil{
+    if err := c.watcher.Watch(ctx, &{{ group_import_name $ }}.{{ $resource.Kind }}{}, handler, predicates...); err != nil{
         return err
     }
     return nil
@@ -93,7 +93,7 @@ type generic{{ $resource.Kind }}Handler struct {
 }
 
 func (h generic{{ $resource.Kind }}Handler) Create(object runtime.Object) error {
-    obj, ok := object.(*autopilot_kind_import.{{ $resource.Kind }})
+    obj, ok := object.(*{{ group_import_name $ }}.{{ $resource.Kind }})
     if !ok {
         return errors.Errorf("internal error: {{ $resource.Kind }} handler received event for %T", object)
     }
@@ -101,7 +101,7 @@ func (h generic{{ $resource.Kind }}Handler) Create(object runtime.Object) error 
 }
 
 func (h generic{{ $resource.Kind }}Handler) Delete(object runtime.Object) error {
-    obj, ok := object.(*autopilot_kind_import.{{ $resource.Kind }})
+    obj, ok := object.(*{{ group_import_name $ }}.{{ $resource.Kind }})
     if !ok {
         return errors.Errorf("internal error: {{ $resource.Kind }} handler received event for %T", object)
     }
@@ -109,11 +109,11 @@ func (h generic{{ $resource.Kind }}Handler) Delete(object runtime.Object) error 
 }
 
 func (h generic{{ $resource.Kind }}Handler) Update(old, new runtime.Object) error {
-    objOld, ok := old.(*autopilot_kind_import.{{ $resource.Kind }})
+    objOld, ok := old.(*{{ group_import_name $ }}.{{ $resource.Kind }})
     if !ok {
         return errors.Errorf("internal error: {{ $resource.Kind }} handler received event for %T", old)
     }
-    objNew, ok := new.(*autopilot_kind_import.{{ $resource.Kind }})
+    objNew, ok := new.(*{{ group_import_name $ }}.{{ $resource.Kind }})
     if !ok {
         return errors.Errorf("internal error: {{ $resource.Kind }} handler received event for %T", new)
     }
@@ -121,7 +121,7 @@ func (h generic{{ $resource.Kind }}Handler) Update(old, new runtime.Object) erro
 }
 
 func (h generic{{ $resource.Kind }}Handler) Generic(object runtime.Object) error {
-    obj, ok := object.(*autopilot_kind_import.{{ $resource.Kind }})
+    obj, ok := object.(*{{ group_import_name $ }}.{{ $resource.Kind }})
     if !ok {
         return errors.Errorf("internal error: {{ $resource.Kind }} handler received event for %T", object)
     }

--- a/codegen/test/api/things.test.io/v1/controller/controller.go
+++ b/codegen/test/api/things.test.io/v1/controller/controller.go
@@ -4,7 +4,7 @@ package controller
 import (
 	"context"
 
-	. "github.com/solo-io/autopilot/codegen/test/api/things.test.io/v1"
+	autopilot_kind_import "github.com/solo-io/autopilot/codegen/test/api/things.test.io/v1"
 
 	"github.com/pkg/errors"
 	"github.com/solo-io/autopilot/pkg/events"
@@ -14,41 +14,41 @@ import (
 )
 
 type PaintEventHandler interface {
-	Create(obj *Paint) error
-	Update(old, new *Paint) error
-	Delete(obj *Paint) error
-	Generic(obj *Paint) error
+	Create(obj *autopilot_kind_import.Paint) error
+	Update(old, new *autopilot_kind_import.Paint) error
+	Delete(obj *autopilot_kind_import.Paint) error
+	Generic(obj *autopilot_kind_import.Paint) error
 }
 
 type PaintEventHandlerFuncs struct {
-	OnCreate  func(obj *Paint) error
-	OnUpdate  func(old, new *Paint) error
-	OnDelete  func(obj *Paint) error
-	OnGeneric func(obj *Paint) error
+	OnCreate  func(obj *autopilot_kind_import.Paint) error
+	OnUpdate  func(old, new *autopilot_kind_import.Paint) error
+	OnDelete  func(obj *autopilot_kind_import.Paint) error
+	OnGeneric func(obj *autopilot_kind_import.Paint) error
 }
 
-func (f *PaintEventHandlerFuncs) Create(obj *Paint) error {
+func (f *PaintEventHandlerFuncs) Create(obj *autopilot_kind_import.Paint) error {
 	if f.OnCreate == nil {
 		return nil
 	}
 	return f.OnCreate(obj)
 }
 
-func (f *PaintEventHandlerFuncs) Delete(obj *Paint) error {
+func (f *PaintEventHandlerFuncs) Delete(obj *autopilot_kind_import.Paint) error {
 	if f.OnDelete == nil {
 		return nil
 	}
 	return f.OnDelete(obj)
 }
 
-func (f *PaintEventHandlerFuncs) Update(objOld, objNew *Paint) error {
+func (f *PaintEventHandlerFuncs) Update(objOld, objNew *autopilot_kind_import.Paint) error {
 	if f.OnUpdate == nil {
 		return nil
 	}
 	return f.OnUpdate(objOld, objNew)
 }
 
-func (f *PaintEventHandlerFuncs) Generic(obj *Paint) error {
+func (f *PaintEventHandlerFuncs) Generic(obj *autopilot_kind_import.Paint) error {
 	if f.OnGeneric == nil {
 		return nil
 	}
@@ -64,7 +64,7 @@ type PaintControllerImpl struct {
 }
 
 func NewPaintController(name string, mgr manager.Manager) (PaintController, error) {
-	if err := AddToScheme(mgr.GetScheme()); err != nil {
+	if err := autopilot_kind_import.AddToScheme(mgr.GetScheme()); err != nil {
 		return nil, err
 	}
 
@@ -79,7 +79,7 @@ func NewPaintController(name string, mgr manager.Manager) (PaintController, erro
 
 func (c *PaintControllerImpl) AddEventHandler(ctx context.Context, h PaintEventHandler, predicates ...predicate.Predicate) error {
 	handler := genericPaintHandler{handler: h}
-	if err := c.watcher.Watch(ctx, &Paint{}, handler, predicates...); err != nil {
+	if err := c.watcher.Watch(ctx, &autopilot_kind_import.Paint{}, handler, predicates...); err != nil {
 		return err
 	}
 	return nil
@@ -91,7 +91,7 @@ type genericPaintHandler struct {
 }
 
 func (h genericPaintHandler) Create(object runtime.Object) error {
-	obj, ok := object.(*Paint)
+	obj, ok := object.(*autopilot_kind_import.Paint)
 	if !ok {
 		return errors.Errorf("internal error: Paint handler received event for %T", object)
 	}
@@ -99,7 +99,7 @@ func (h genericPaintHandler) Create(object runtime.Object) error {
 }
 
 func (h genericPaintHandler) Delete(object runtime.Object) error {
-	obj, ok := object.(*Paint)
+	obj, ok := object.(*autopilot_kind_import.Paint)
 	if !ok {
 		return errors.Errorf("internal error: Paint handler received event for %T", object)
 	}
@@ -107,11 +107,11 @@ func (h genericPaintHandler) Delete(object runtime.Object) error {
 }
 
 func (h genericPaintHandler) Update(old, new runtime.Object) error {
-	objOld, ok := old.(*Paint)
+	objOld, ok := old.(*autopilot_kind_import.Paint)
 	if !ok {
 		return errors.Errorf("internal error: Paint handler received event for %T", old)
 	}
-	objNew, ok := new.(*Paint)
+	objNew, ok := new.(*autopilot_kind_import.Paint)
 	if !ok {
 		return errors.Errorf("internal error: Paint handler received event for %T", new)
 	}
@@ -119,7 +119,7 @@ func (h genericPaintHandler) Update(old, new runtime.Object) error {
 }
 
 func (h genericPaintHandler) Generic(object runtime.Object) error {
-	obj, ok := object.(*Paint)
+	obj, ok := object.(*autopilot_kind_import.Paint)
 	if !ok {
 		return errors.Errorf("internal error: Paint handler received event for %T", object)
 	}

--- a/codegen/test/api/things.test.io/v1/controller/controller.go
+++ b/codegen/test/api/things.test.io/v1/controller/controller.go
@@ -4,7 +4,7 @@ package controller
 import (
 	"context"
 
-	autopilot_kind_import "github.com/solo-io/autopilot/codegen/test/api/things.test.io/v1"
+	things_test_io_v1 "github.com/solo-io/autopilot/codegen/test/api/things.test.io/v1"
 
 	"github.com/pkg/errors"
 	"github.com/solo-io/autopilot/pkg/events"
@@ -14,41 +14,41 @@ import (
 )
 
 type PaintEventHandler interface {
-	Create(obj *autopilot_kind_import.Paint) error
-	Update(old, new *autopilot_kind_import.Paint) error
-	Delete(obj *autopilot_kind_import.Paint) error
-	Generic(obj *autopilot_kind_import.Paint) error
+	Create(obj *things_test_io_v1.Paint) error
+	Update(old, new *things_test_io_v1.Paint) error
+	Delete(obj *things_test_io_v1.Paint) error
+	Generic(obj *things_test_io_v1.Paint) error
 }
 
 type PaintEventHandlerFuncs struct {
-	OnCreate  func(obj *autopilot_kind_import.Paint) error
-	OnUpdate  func(old, new *autopilot_kind_import.Paint) error
-	OnDelete  func(obj *autopilot_kind_import.Paint) error
-	OnGeneric func(obj *autopilot_kind_import.Paint) error
+	OnCreate  func(obj *things_test_io_v1.Paint) error
+	OnUpdate  func(old, new *things_test_io_v1.Paint) error
+	OnDelete  func(obj *things_test_io_v1.Paint) error
+	OnGeneric func(obj *things_test_io_v1.Paint) error
 }
 
-func (f *PaintEventHandlerFuncs) Create(obj *autopilot_kind_import.Paint) error {
+func (f *PaintEventHandlerFuncs) Create(obj *things_test_io_v1.Paint) error {
 	if f.OnCreate == nil {
 		return nil
 	}
 	return f.OnCreate(obj)
 }
 
-func (f *PaintEventHandlerFuncs) Delete(obj *autopilot_kind_import.Paint) error {
+func (f *PaintEventHandlerFuncs) Delete(obj *things_test_io_v1.Paint) error {
 	if f.OnDelete == nil {
 		return nil
 	}
 	return f.OnDelete(obj)
 }
 
-func (f *PaintEventHandlerFuncs) Update(objOld, objNew *autopilot_kind_import.Paint) error {
+func (f *PaintEventHandlerFuncs) Update(objOld, objNew *things_test_io_v1.Paint) error {
 	if f.OnUpdate == nil {
 		return nil
 	}
 	return f.OnUpdate(objOld, objNew)
 }
 
-func (f *PaintEventHandlerFuncs) Generic(obj *autopilot_kind_import.Paint) error {
+func (f *PaintEventHandlerFuncs) Generic(obj *things_test_io_v1.Paint) error {
 	if f.OnGeneric == nil {
 		return nil
 	}
@@ -64,7 +64,7 @@ type PaintControllerImpl struct {
 }
 
 func NewPaintController(name string, mgr manager.Manager) (PaintController, error) {
-	if err := autopilot_kind_import.AddToScheme(mgr.GetScheme()); err != nil {
+	if err := things_test_io_v1.AddToScheme(mgr.GetScheme()); err != nil {
 		return nil, err
 	}
 
@@ -79,7 +79,7 @@ func NewPaintController(name string, mgr manager.Manager) (PaintController, erro
 
 func (c *PaintControllerImpl) AddEventHandler(ctx context.Context, h PaintEventHandler, predicates ...predicate.Predicate) error {
 	handler := genericPaintHandler{handler: h}
-	if err := c.watcher.Watch(ctx, &autopilot_kind_import.Paint{}, handler, predicates...); err != nil {
+	if err := c.watcher.Watch(ctx, &things_test_io_v1.Paint{}, handler, predicates...); err != nil {
 		return err
 	}
 	return nil
@@ -91,7 +91,7 @@ type genericPaintHandler struct {
 }
 
 func (h genericPaintHandler) Create(object runtime.Object) error {
-	obj, ok := object.(*autopilot_kind_import.Paint)
+	obj, ok := object.(*things_test_io_v1.Paint)
 	if !ok {
 		return errors.Errorf("internal error: Paint handler received event for %T", object)
 	}
@@ -99,7 +99,7 @@ func (h genericPaintHandler) Create(object runtime.Object) error {
 }
 
 func (h genericPaintHandler) Delete(object runtime.Object) error {
-	obj, ok := object.(*autopilot_kind_import.Paint)
+	obj, ok := object.(*things_test_io_v1.Paint)
 	if !ok {
 		return errors.Errorf("internal error: Paint handler received event for %T", object)
 	}
@@ -107,11 +107,11 @@ func (h genericPaintHandler) Delete(object runtime.Object) error {
 }
 
 func (h genericPaintHandler) Update(old, new runtime.Object) error {
-	objOld, ok := old.(*autopilot_kind_import.Paint)
+	objOld, ok := old.(*things_test_io_v1.Paint)
 	if !ok {
 		return errors.Errorf("internal error: Paint handler received event for %T", old)
 	}
-	objNew, ok := new.(*autopilot_kind_import.Paint)
+	objNew, ok := new.(*things_test_io_v1.Paint)
 	if !ok {
 		return errors.Errorf("internal error: Paint handler received event for %T", new)
 	}
@@ -119,7 +119,7 @@ func (h genericPaintHandler) Update(old, new runtime.Object) error {
 }
 
 func (h genericPaintHandler) Generic(object runtime.Object) error {
-	obj, ok := object.(*autopilot_kind_import.Paint)
+	obj, ok := object.(*things_test_io_v1.Paint)
 	if !ok {
 		return errors.Errorf("internal error: Paint handler received event for %T", object)
 	}

--- a/codegen/test/api/things.test.io/v1/test_api.pb.go
+++ b/codegen/test/api/things.test.io/v1/test_api.pb.go
@@ -5,8 +5,9 @@ package v1
 
 import (
 	fmt "fmt"
-	proto "github.com/gogo/protobuf/proto"
 	math "math"
+
+	proto "github.com/gogo/protobuf/proto"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.

--- a/codegen/test/api/things.test.io/v1/test_api_json.gen.go
+++ b/codegen/test/api/things.test.io/v1/test_api_json.gen.go
@@ -6,9 +6,10 @@ package v1
 import (
 	bytes "bytes"
 	fmt "fmt"
+	math "math"
+
 	github_com_gogo_protobuf_jsonpb "github.com/gogo/protobuf/jsonpb"
 	proto "github.com/gogo/protobuf/proto"
-	math "math"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.

--- a/go.mod
+++ b/go.mod
@@ -20,13 +20,17 @@ require (
 	github.com/gophercloud/gophercloud v0.2.0 // indirect
 	github.com/iancoleman/strcase v0.0.0-20191112232945-16388991a334
 	github.com/karrick/godirwalk v1.14.1 // indirect
+	github.com/lyft/protoc-gen-validate v0.1.0 // indirect
 	github.com/mitchellh/go-homedir v1.1.0
+	github.com/mwitkow/go-proto-validators v0.3.0 // indirect
 	github.com/onsi/ginkgo v1.11.0
 	github.com/onsi/gomega v1.8.1
 	github.com/pborman/uuid v1.2.0
 	github.com/pkg/errors v0.8.1
 	github.com/prometheus/client_golang v1.2.1
 	github.com/prometheus/common v0.7.0
+	github.com/pseudomuto/protoc-gen-doc v1.3.0 // indirect
+	github.com/pseudomuto/protokit v0.2.0 // indirect
 	github.com/rogpeppe/go-internal v1.5.2
 	github.com/sirupsen/logrus v1.4.2
 	github.com/solo-io/anyvendor v0.0.1
@@ -39,7 +43,7 @@ require (
 	golang.org/x/crypto v0.0.0-20200117160349-530e935923ad // indirect
 	golang.org/x/sys v0.0.0-20200117145432-59e60aa80a0c // indirect
 	golang.org/x/tools v0.0.0-20191029190741-b9c20aec41a5
-	istio.io/tools v0.0.0-20200128155652-36eceb1fcb9d // indirect
+	istio.io/tools v0.0.0-20200214155848-b0036b2c2d76 // indirect
 	k8s.io/api v0.17.1
 	k8s.io/apiextensions-apiserver v0.0.0-20191016113550-5357c4baaf65
 	k8s.io/apimachinery v0.17.1

--- a/go.sum
+++ b/go.sum
@@ -464,6 +464,8 @@ github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de/go.mod h1:zAbeS9
 github.com/lithammer/dedent v1.1.0/go.mod h1:jrXYCQtgg0nJiN+StA2KgR7w6CiQNv9Fd/Z9BP0jIOc=
 github.com/lyft/protoc-gen-star v0.4.14 h1:HUkD4H4dYFIgu3Bns/3N6J5GmKHCEGnhYBwNu3fvXgA=
 github.com/lyft/protoc-gen-star v0.4.14/go.mod h1:mE8fbna26u7aEA2QCVvvfBU/ZrPgocG1206xAFPcs94=
+github.com/lyft/protoc-gen-validate v0.1.0 h1:NytKd9K7UW7Szxn+9PYNsaJ/98TL/WsDq4ro4ZVuh5o=
+github.com/lyft/protoc-gen-validate v0.1.0/go.mod h1:XbGvPuh87YZc5TdIa2/I4pLk0QoUACkjt2znoq26NVQ=
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/mailru/easyjson v0.0.0-20160728113105-d5b7844b561a/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
 github.com/mailru/easyjson v0.0.0-20180823135443-60711f1a8329/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
@@ -519,6 +521,8 @@ github.com/morikuni/aec v0.0.0-20170113033406-39771216ff4c/go.mod h1:BbKIizmSmc5
 github.com/mpvl/unique v0.0.0-20150818121801-cbe035fff7de/go.mod h1:kJun4WP5gFuHZgRjZUWWuH1DTxCtxbHDOIJsudS8jzY=
 github.com/munnerz/goautoneg v0.0.0-20120707110453-a547fc61f48d/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
+github.com/mwitkow/go-proto-validators v0.3.0 h1:2WkInbIheqmDevK9h0S/K6f0Os/HlTPGJeRwDAeQE1w=
+github.com/mwitkow/go-proto-validators v0.3.0/go.mod h1:ej0Qp0qMgHN/KtDyUt+Q1/tA7a5VarXUOUxD+oeD30w=
 github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f/go.mod h1:ZdcZmHo+o7JKHSa8/e818NopupXU1YMK5fe1lsApnBw=
 github.com/natefinch/lumberjack v2.0.0+incompatible/go.mod h1:Wi9p2TTF5DG5oU+6YfsmYQpsTIOm0B1VNzQg9Mw6nPk=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
@@ -591,7 +595,12 @@ github.com/prometheus/procfs v0.0.2/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsT
 github.com/prometheus/procfs v0.0.5 h1:3+auTFlqw+ZaQYJARz6ArODtkaIwtvBTx3N2NehQlL8=
 github.com/prometheus/procfs v0.0.5/go.mod h1:4A/X28fw3Fc593LaREMrKMqOKvUAntwMDaekg4FpcdQ=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
+github.com/pseudomuto/protoc-gen-doc v1.0.0 h1:g4ld0LeJ2OO2FXhm1o7Arrv+W75sdEClxuvVUSN2RAE=
 github.com/pseudomuto/protoc-gen-doc v1.0.0/go.mod h1:fwtQAY9erXp3mC92O8OTECnDlJT2r0Ff4KSEKbGEmy0=
+github.com/pseudomuto/protoc-gen-doc v1.3.0 h1:wpwmaSCWY2lGwkzAxAaqYcGyoklZjZmeXrJ/X7IskJM=
+github.com/pseudomuto/protoc-gen-doc v1.3.0/go.mod h1:fwtQAY9erXp3mC92O8OTECnDlJT2r0Ff4KSEKbGEmy0=
+github.com/pseudomuto/protokit v0.2.0 h1:hlnBDcy3YEDXH7kc9gV+NLaN0cDzhDvD1s7Y6FZ8RpM=
+github.com/pseudomuto/protokit v0.2.0/go.mod h1:2PdH30hxVHsup8KpBTOXTBeMVhJZVio3Q8ViKSAXT0Q=
 github.com/radovskyb/watcher v1.0.2/go.mod h1:78okwvY5wPdzcb1UYnip1pvrZNIVEIh/Cm+ZuvsUYIg=
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/remyoudompheng/bigfft v0.0.0-20170806203942-52369c62f446/go.mod h1:uYEyJGbgTkfkS4+E/PavXkNJcbFIpEtjt2B0KDQ5+9M=
@@ -875,6 +884,7 @@ google.golang.org/genproto v0.0.0-20190425155659-357c62f0e4bb/go.mod h1:VzzqZJRn
 google.golang.org/genproto v0.0.0-20190502173448-54afdca5d873/go.mod h1:VzzqZJRnGkLBvHegQrXjBqPurQTc5/KpmUdxsrq26oE=
 google.golang.org/genproto v0.0.0-20190530194941-fb225487d101/go.mod h1:z3L6/3dTEVtUr6QSP8miRzeRqwQOioJ9I66odjN4I7s=
 google.golang.org/genproto v0.0.0-20190819201941-24fa4b261c55/go.mod h1:DMBHOl98Agz4BDEuKkezgsaosCRResVns1a3J2ZsMNc=
+google.golang.org/genproto v0.0.0-20191028173616-919d9bdd9fe6 h1:UXl+Zk3jqqcbEVV7ace5lrt4YdA4tXiz3f/KbmD29Vo=
 google.golang.org/genproto v0.0.0-20191028173616-919d9bdd9fe6/go.mod h1:n3cpQtvxv34hfy77yVDNjmbRyujviMdxYliBSkLhpCc=
 google.golang.org/grpc v1.13.0/go.mod h1:yo6s7OP7yaDglbqo1J04qKzAhqBH6lvTonzMVmEdcZw=
 google.golang.org/grpc v1.14.0/go.mod h1:yo6s7OP7yaDglbqo1J04qKzAhqBH6lvTonzMVmEdcZw=
@@ -931,6 +941,8 @@ istio.io/tools v0.0.0-20200117200958-8b2f24232142 h1:srbSLe6Q6icR6ociYksE7fPaM6n
 istio.io/tools v0.0.0-20200117200958-8b2f24232142/go.mod h1:6u5K87o8AZvfCdPhr0M60yuZR5/4pPCOCiokv7P+I+0=
 istio.io/tools v0.0.0-20200128155652-36eceb1fcb9d h1:XR0dBGt0upeD2PGAwWABjxQK7D0WabvCeW+HUzNRSeA=
 istio.io/tools v0.0.0-20200128155652-36eceb1fcb9d/go.mod h1:6u5K87o8AZvfCdPhr0M60yuZR5/4pPCOCiokv7P+I+0=
+istio.io/tools v0.0.0-20200214155848-b0036b2c2d76 h1:ZY1ZU7Ajf47kTY3ziBvGQnub7Rs8oZfJfq22Wo60qq0=
+istio.io/tools v0.0.0-20200214155848-b0036b2c2d76/go.mod h1:6u5K87o8AZvfCdPhr0M60yuZR5/4pPCOCiokv7P+I+0=
 k8s.io/api v0.0.0-20190918155943-95b840bb6a1f/go.mod h1:uWuOHnjmNrtQomJrvEBg0c0HRNyQ+8KTEERVsK0PW48=
 k8s.io/api v0.0.0-20191004120003-3a12735a829a/go.mod h1:ceHJE/vDjU8jKnRV6Vqn/+vyZmC6NvOluInN+RhQkIs=
 k8s.io/api v0.0.0-20191004120104-195af9ec3521 h1:StP5An9aFEWfPckudvHEJc4q/WUDCUVGoZJrE/efGME=

--- a/pkg/ezkube/mocks/dynamic_client.go
+++ b/pkg/ezkube/mocks/dynamic_client.go
@@ -6,9 +6,10 @@ package mock_ezkube
 
 import (
 	context "context"
+	reflect "reflect"
+
 	gomock "github.com/golang/mock/gomock"
 	ezkube "github.com/solo-io/autopilot/pkg/ezkube"
-	reflect "reflect"
 	client "sigs.k8s.io/controller-runtime/pkg/client"
 	manager "sigs.k8s.io/controller-runtime/pkg/manager"
 )


### PR DESCRIPTION
Using a dot import confuses mockgen when it runs against an interface like the following:

```
package my_application

//go:generate ....

type Foo interface {
  Method1()
  Methodn()

  controller.DeploymentEventHandler // this is a generated autopilot type
}
```
mockgen thinks that the method `Create(obj *Deployment)` from the generated autopilot code should be generated into a mock as `Create(obj *my_application.Deployment)` rather than `Create(obj *controller.Deployment)`